### PR TITLE
開発サーバー起動順変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "preinstall": "npx only-allow npm",
     "dev:server": "npm run dev -w server",
-    "dev:client": "sleep 3 && npm run dev -w client",
+    "dev:client": "scripts/start_client.sh",
     "start": "run-p dev:*"
   },
   "devDependencies": {

--- a/scripts/start_client.sh
+++ b/scripts/start_client.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+PORT=3000
+
+if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null; then
+  kill $(lsof -t -i:$PORT)
+fi
+
+while ! nc -z localhost $PORT; do
+  sleep 1
+done
+
+npm run dev -w client


### PR DESCRIPTION
## 概要

https://github.com/gizumo-education/react-app/issues/3

## やったこと

- APIサーバーの起動後にクライアント側のサーバーが起動するように変更

## やらないこと

なし

## 動作確認

- APIサーバー起動後にクライアント側のサーバーが起動すること
- ポート3000のプロセスが実行中であれば、実行中のプロセスを終了させた後にAPIサーバーが起動すること

## その他

npm scriptsのコマンド名は変更していないため、カリキュラムの変更は不要の想定。